### PR TITLE
Add support for input_event's new info map

### DIFF
--- a/lib/scenic_driver_nerves_touch.ex
+++ b/lib/scenic_driver_nerves_touch.ex
@@ -14,7 +14,7 @@ defmodule Scenic.Driver.Nerves.Touch do
   days for this driver. There will probably be changes in the future. Especially
   regarding multi-touch.
 
-  For now, the events coming to a scene via the touch driver look like the 
+  For now, the events coming to a scene via the touch driver look like the
   same cursor oriented events that come from glfw with a mouse.
 
   ## Installation
@@ -71,7 +71,7 @@ defmodule Scenic.Driver.Nerves.Touch do
 
   ## Calibration
 
-  Calibration maps the resolution/coordinates of the touch screen to the 
+  Calibration maps the resolution/coordinates of the touch screen to the
   coordinates and scale of the display. On the official Raspberry Pi
   7" touch screen, then are the same, so the mapping is easy (1.0).
 
@@ -198,12 +198,22 @@ defmodule Scenic.Driver.Nerves.Touch do
   # If it is found, connect and start working for real
   def handle_info({:init_driver, requested_device}, state) do
     InputEvent.enumerate()
-    |> Enum.find_value(fn {event, device_name} ->
-      if device_name =~ requested_device do
-        event
-      else
-        nil
-      end
+    |> Enum.find_value(fn
+      # input_event 0.3.1
+      {event, device_name} when is_binary(device_name) ->
+        if device_name =~ requested_device do
+          event
+        else
+          nil
+        end
+
+      # input_event >= 0.4.0
+      {event, info} when is_map(info) ->
+        if info.name =~ requested_device do
+          event
+        else
+          nil
+        end
     end)
     |> case do
       nil ->


### PR DESCRIPTION
`input_event` now provides a lot of information about input devices
during enumeration, but that broke the name matching code. This is a
minimal patch to support both the current input_event v0.3.1 way and the
new info map way once it's released.

You can see the new information for the Raspberry Pi Touchscreen in https://github.com/LeToteTeam/input_event/pull/7. I think it should be possible to make the touch screen code pretty generic whenever someone next takes a pass at it.