### PR TITLE
Fix message format of cursor_button event

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,15 @@ to the driver list in your ViewPort's config.exs file.
           size: {800, 480},
           default_scene: {Sample.Scene.Simple, nil},
           drivers: [
-            %{
-              module: Scenic.Driver.Nerves.Rpi,
-            },
-            %{
+            [
+              module: Scenic.Driver.Local,
+              position: [scaled: true, centered: true, orientation: :normal]
+            ],
+            [
               module: Scenic.Driver.Nerves.Touch,
-              opts: [
-                device: "FT5406 memory based driver",
-                calibration: {{1,0,0},{0,1,0}}
-              ],
-            }
+              device: "raspberrypi-ts",
+              calibration: {{1, 0, 0}, {0, 1, 0}}
+            ]
           ]
         }
 

--- a/lib/scenic_driver_nerves_touch.ex
+++ b/lib/scenic_driver_nerves_touch.ex
@@ -253,8 +253,8 @@ defmodule Scenic.Driver.Nerves.Touch do
     # if the button/touch state changed. send cursor_button
     case new_touch do
       ^old_touch -> driver
-      true -> send_input(driver, {:cursor_button, {0, :press, 0, new_position}})
-      false -> send_input(driver, {:cursor_button, {0, :release, 0, new_position}})
+      true -> send_input(driver, {:cursor_button, {:btn_left, 1, [], new_position}})
+      false -> send_input(driver, {:cursor_button, {:btn_left, 0, [], new_position}})
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ScenicDriverNervesTouch.MixProject do
   defp deps do
     [
       {:input_event, "~> 0.4"},
-      {:scenic, "~> 0.10"},
+      {:scenic, "~> 0.11.0-beta.0"},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
     ]
   end


### PR DESCRIPTION
- Update configuration sample in the README
- Fix message format of cursor_button event. The scenic was throwing this error msg:

<img width="948" alt="Screen Shot 2022-06-06 at 3 11 22 PM" src="https://user-images.githubusercontent.com/1548203/172257764-f0e0603e-1fed-4023-8be7-6f3a442e2dea.png">
